### PR TITLE
CMake: set default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.8.12)
 project(JsonSettingsQml VERSION 1.0 LANGUAGES CXX C)
 
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
+
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     message(STATUS "Debug type: " ${CMAKE_BUILD_TYPE})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_QML_DEBUG -DQT_DECLARATIVE_DEBUG -O0 -g")


### PR DESCRIPTION
Building outside of Qt-Creator complains:

| CMake Error at CMakeLists.txt:5 (if):
|   if given arguments:
|
|     "STREQUAL" "Debug"
|
|   Unknown arguments specified

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>