### PR TITLE
JsonSettingsFile: Add a property fireChangeOnSet unset by default

### DIFF
--- a/src/jsonsettingsfile.cpp
+++ b/src/jsonsettingsfile.cpp
@@ -21,6 +21,8 @@ class JsonSettingsFilePrivate {
     QTimer m_transactionTimer;
     bool m_autoWriteBackEnabled=false;
 
+    bool m_bfireChangeOnSet=false;
+
     Q_DECLARE_PUBLIC(JsonSettingsFile)
 };
 
@@ -163,7 +165,9 @@ bool JsonSettingsFile::setOption(const QString &t_key, const QString &t_value)
         d->m_dataHolder.insert(t_key, t_value);
         retVal=true;
         emit settingsSaveRequest(this);
-        emit settingsChanged(this);
+        if(d_ptr->m_bfireChangeOnSet) {
+            emit settingsChanged(this);
+        }
     }
     return retVal;
 }
@@ -194,6 +198,19 @@ void JsonSettingsFile::setAutoWriteBackEnabled(bool t_autoWriteBackEnabled)
 {
     if(d_ptr->m_autoWriteBackEnabled != t_autoWriteBackEnabled) {
         d_ptr->m_autoWriteBackEnabled=t_autoWriteBackEnabled;
+    }
+}
+
+bool JsonSettingsFile::fireChangeOnSet() const
+{
+    return d_ptr->m_bfireChangeOnSet;
+}
+
+void JsonSettingsFile::setFireChangeOnSet(bool enabled)
+{
+    if(enabled != d_ptr->m_bfireChangeOnSet) {
+        d_ptr->m_bfireChangeOnSet = enabled;
+        emit fireChangeOnSetChanged();
     }
 }
 

--- a/src/jsonsettingsfile.h
+++ b/src/jsonsettingsfile.h
@@ -25,16 +25,21 @@ public:
   Q_INVOKABLE QString getOption(const QString &t_key, const QString &t_valueDefault);
   Q_INVOKABLE bool setOption(const QString &t_key, const QString &t_value);
   Q_INVOKABLE bool dropOption(const QString &t_key);
+  Q_PROPERTY(bool fireChangeOnSet READ fireChangeOnSet WRITE setFireChangeOnSet NOTIFY fireChangeOnSetChanged)
 
   Q_INVOKABLE bool autoWriteBackEnabled() const;
   Q_INVOKABLE void setAutoWriteBackEnabled(bool t_autoWriteBackEnabled=true);
 signals:
   void settingsChanged(JsonSettingsFile *settingsFile);
   void settingsSaveRequest(JsonSettingsFile *settingsFile);
+  void fireChangeOnSetChanged();
 
 public slots:
 
 private:
+  bool fireChangeOnSet() const;
+  void setFireChangeOnSet(bool enabled);
+
   JsonSettingsFilePrivate *d_ptr;
 
   static JsonSettingsFile *s_globalSettings;


### PR DESCRIPTION
Although we enhanced situation in vf-declarative-gui firing change on change of
any property is still a bad thing to do: Each setOption causes all (~50)
settings to call getOption.

In the long run we need a major rework here: Current solution does not fit to
good performing QML.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>